### PR TITLE
The reinstall action needs to provide --force to 'pyenv install'

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'shane@dasilva.io'
 license          'Apache 2.0'
 description      'Manages pyenv and its installed Python versions, also providing several LWRPs.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '0.1.0'
+version          '0.1.1'
 
 %w[amazon centos debian fedora freebsd mac_os_x redhat scientific suse ubuntu].each do |os|
   supports os

--- a/providers/python.rb
+++ b/providers/python.rb
@@ -29,7 +29,13 @@ def perform_install
     pyenv_user    = @user
     pyenv_prefix  = @root_path
     pyenv_env     = @environment
-    command       = %{pyenv install #{@python}}
+
+    if Array(new_resource.action).include?(:reinstall)
+      # Reinstall requires the --force/-f option
+      command       = %{pyenv install -f #{@python}}
+    else
+      command       = %{pyenv install #{@python}}
+    end
 
     pyenv_script "#{command} #{which_pyenv}" do
       code        command


### PR DESCRIPTION
Hello all!

We use this cookbook at IBM Cloudant to manage pyenv python for a few applications. We found that when we upgrade system packages which python links against, pyenv python would need to be reinstalled to pick up the upgraded libs.

The `:reinstall` action sounds apt, but it looks like it also needs the `--force/-f` option as provided by pyenv.

```
pyenv install -h
...
 -f/--force         Install even if the version appears to be installed already
...
```

This change enabled us to use the `:reinstall` action to conditionally rebuild our pyenv python installs. With the way applications consume pyenv shims this worked quite well.

We found -f necessary as we already had working installs -- they just needed to be rebuilt. Otherwise chef-client will fail as such:

```
Mixlib::ShellOut::ShellCommandFailed
------------------------------------
Expected process to exit with [0], but received '1'
---- Begin output of "bash"  "/tmp/chef-script20160608-12732-5qwbww" ----
STDOUT: 
STDERR: pyenv: /usr/local/pyenv/versions/2.7.10 already exists
```

I was hoping this small change could help others. Let me know what you think!